### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["panos@olavm.org"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 keywords = ["abi", "ola", "olac", ]
 documentation = "https://olang.gitbook.io/ola-lang/"
-homepage = "https://github.com/Sin7Y/ola-lang-abi"
+repository = "https://github.com/Sin7Y/ola-lang-abi"
 
 [dependencies]
 anyhow = { version = "1.0.75", default-features = false, features = ["std"] }


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.